### PR TITLE
Remove package name for accuracy test tool

### DIFF
--- a/samples/mlops-for-azure-custom-question-answering/accuracy_test/package-lock.json
+++ b/samples/mlops-for-azure-custom-question-answering/accuracy_test/package-lock.json
@@ -1,5 +1,4 @@
 {
-  "name": "accuracy-test",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -370,9 +369,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {

--- a/samples/mlops-for-azure-custom-question-answering/accuracy_test/package.json
+++ b/samples/mlops-for-azure-custom-question-answering/accuracy_test/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "accuracy-test",
   "version": "1.0.0",
   "description": "QnA Bot Accuracy Batch Test Tool",
+  "private": true,
   "author": "Microsoft",
   "license": "MIT",
   "main": "./lib/evaluateAccuracy.js",


### PR DESCRIPTION
## Why

To avoid users to unintentional do a `npm install <packagename>` which could result in downloading a package with same name from public npm registry which could hold malicious code

## How

Remove unnecessary package name and mark as private